### PR TITLE
Make Compatible on *nix Systems

### DIFF
--- a/src/routes/wsRouter.js
+++ b/src/routes/wsRouter.js
@@ -1,5 +1,5 @@
 const WebSocket = require('ws');
-const { generateImage } = require('../utils/comfyUi');
+const { generateImage } = require('../utils/comfyUI.js');
 
 const wss = new WebSocket.Server({ noServer: true });
 


### PR DESCRIPTION
ComfyUIMini wouldn't start on my Linux system until I changed the `../utils/comfyUi` module name to `../utils/comfyUI.js`. My best guess is that the primary developer only tested on a Windows system, where filenames are not case-sensitive, so `Ui` and `UI` would both work there.

(In addition to the uppercase-fix, I also added the `.js` extension to be safe, but it might not actually be necessary? It should work either way, this is just more precise.)